### PR TITLE
more non-async compat with new feature flag `client` and `::from_response` methods and `*_request` methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v1
         id: cache
         with:
-          path: | 
+          path: |
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git
@@ -65,7 +65,6 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -81,17 +80,22 @@ jobs:
         uses: actions/cache@v1
         id: cache
         with:
-          path: | 
+          path: |
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --locked
       - name: Run clippy --all-targets --all-features
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --locked --all-targets --all-features 
+          args: --locked --all-targets --all-features
   docs:
     name: Docs
     runs-on: ubuntu-latest
@@ -106,7 +110,7 @@ jobs:
         uses: actions/cache@v1
         id: cache
         with:
-          path: | 
+          path: |
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
 
 ### Breaking
 
-* Added new feature flag `client` that enables client specific functions. Without this feature,
+- Added new feature flag `client` that enables client specific functions. Without this feature,
   `twitch_oauth2` will only provide non-async functions and
-  provide library users `http::Request`s and consume `http::Response`s.
+  provide library users functions that returns `http::Request`s and consume `http::Response`s.
+- `ValidatedToken::expires_in` is now an `Option`.
 
 ## [v0.8.0] - 2022-08-27
 
@@ -18,8 +19,8 @@
 
 ### Breaking
 
-* Bumped `aliri_braid` to `0.2`, this change means that the `new` method on the types in `types` only take an owned string now
-  * `AccessToken::new`, `ClientId::new`, `ClientSecret::new`, `CsrfToken::new` and `RefreshToken::new` now take a `String` instead of `impl Into<String>`
+- Bumped `aliri_braid` to `0.2`, this change means that the `new` method on the types in `types` only take an owned string now
+  - `AccessToken::new`, `ClientId::new`, `ClientSecret::new`, `CsrfToken::new` and `RefreshToken::new` now take a `String` instead of `impl Into<String>`
 
 ## [v0.7.1] - 2022-08-27
 
@@ -27,11 +28,11 @@
 
 ### Changed
 
-* Organization moved to `twitch-rs`
+- Organization moved to `twitch-rs`
 
 ### Added
 
-* Added scopes `channel:manage:raids`, `channel:manage:moderators`, `channel:manage:vips`, `channel:read:charity`,
+- Added scopes `channel:manage:raids`, `channel:manage:moderators`, `channel:manage:vips`, `channel:read:charity`,
   `channel:read:vips`, `moderator:manage:announcements`, `moderator:manage:chat_messages`, `user:manage:chat_color` and
   `user:manage:whispers`
 
@@ -41,8 +42,8 @@
 
 ### Breaking changes
 
-* switch to [`twitch_types`](https://crates.io/crates/twitch_types) for `UserId` and `Nickname`/`UserName`
-* bump MSRV to 1.60, also changes the feature names for clients to their simpler variant `surf` and `client`
+- switch to [`twitch_types`](https://crates.io/crates/twitch_types) for `UserId` and `Nickname`/`UserName`
+- bump MSRV to 1.60, also changes the feature names for clients to their simpler variant `surf` and `client`
 
 ## [v0.6.1] - 2021-11-23
 
@@ -50,7 +51,7 @@
 
 ### Added
 
-* Added new scopes `moderator:manage:automod_settings`, `moderator:manage:banned_users`,
+- Added new scopes `moderator:manage:automod_settings`, `moderator:manage:banned_users`,
   `moderator:manage:blocked_terms`, `moderator:manage:chat_settings`, `moderator:read:automod_settings`,
   `moderator:read:blocked_terms` and `moderator:read:chat_settings`
 
@@ -60,30 +61,30 @@
 
 ### Breaking changes
 
-* All types associated with tokens are now defined in this crate. This is a consequence of the `oauth2` dependency being removed from tree.
+- All types associated with tokens are now defined in this crate. This is a consequence of the `oauth2` dependency being removed from tree.
   Additionally, as another consequence, clients are now able to be specified as a `for<'a> &'a T where T: Client<'a>`, meaning `twitch_api` can use its clients as an interface to token requests,
   and clients can persist instead of being rebuilt every call. Care should be taken when making clients, as SSRF and similar attacks are possible with improper client configurations.
 
 ### Added
 
-* Added types/braids `ClientId`, `ClientSecret`, `AccessToken`, `RefreshToken` and `CsrfToken`.
-* Added way to interact with the Twitch-CLI [mock API](https://github.com/twitchdev/twitch-cli/blob/main/docs/mock-api.md) using environment variables.
+- Added types/braids `ClientId`, `ClientSecret`, `AccessToken`, `RefreshToken` and `CsrfToken`.
+- Added way to interact with the Twitch-CLI [mock API](https://github.com/twitchdev/twitch-cli/blob/main/docs/mock-api.md) using environment variables.
   See static variables `AUTH_URL`, `TOKEN_URL`, `VALIDATE_URL` and `REVOKE_URL` for more information.
-* Added `impl Borrow<str> for Scope`, meaning it can be used in places it couldn't be used before. Primarily, it allows the following code to work:
+- Added `impl Borrow<str> for Scope`, meaning it can be used in places it couldn't be used before. Primarily, it allows the following code to work:
   ```rust
   let scopes = vec![Scope::ChatEdit, Scope::ChatRead];
   let space_separated_scope: String = scopes.as_slice().join(" ");
   ```
-* Added scope `channel:read:goals`
+- Added scope `channel:read:goals`
 
 ### Changed
 
-* Requests to `id.twitch.tv` now follow the documentation, instead of following a subset of the RFC for oauth2.
-* URLs are now initialized lazily and specified as `url::Url`s.
+- Requests to `id.twitch.tv` now follow the documentation, instead of following a subset of the RFC for oauth2.
+- URLs are now initialized lazily and specified as `url::Url`s.
 
 ### Removed
 
-* Removed `oauth2` dependency.
+- Removed `oauth2` dependency.
 
 ## [v0.5.2] - 2021-06-18
 
@@ -91,7 +92,7 @@
 
 ### Added
 
-* Added new scope `channel:manage:schedule`
+- Added new scope `channel:manage:schedule`
 
 ## [v0.5.1] - 2021-05-16
 
@@ -99,8 +100,8 @@
 
 ### Added
 
-* Added new scopes `channel:manage:polls`, `channel:manage:predictions`, `channel:read:polls`, `channel:read:predictions`, and `moderator:manage:automod`,
-* Added function `Scope::description` to get the description of the scope
+- Added new scopes `channel:manage:polls`, `channel:manage:predictions`, `channel:read:polls`, `channel:read:predictions`, and `moderator:manage:automod`,
+- Added function `Scope::description` to get the description of the scope
 
 ## [v0.5.0] - 2021-05-08
 
@@ -108,19 +109,20 @@
 
 ### Added
 
-* Made crate runtime agnostic with custom clients.
-* Updated deps.
-* Add an extra (optional) client secret field to `UserToken::from_existing` (thanks [Dinnerbone](https://github.com/Dinnerbone))
-* Added `channel:manage:redemptions`, `channel:read:editors`, `channel:manage:videos`, `user:read:blocked_users`,  `user:manage:blocked_users`, `user:read:subscriptions` and `user:read:follows`
-* Implemented [OAuth Authorization Code Flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#oauth-authorization-code-flow) with `UserTokenBuilder`
-* Added a way to suggest or infer that an user token is never expiring, making `is_elapsed` return false and `expires_in` a bogus (max) duration.
+- Made crate runtime agnostic with custom clients.
+- Updated deps.
+- Add an extra (optional) client secret field to `UserToken::from_existing` (thanks [Dinnerbone](https://github.com/Dinnerbone))
+- Added `channel:manage:redemptions`, `channel:read:editors`, `channel:manage:videos`, `user:read:blocked_users`, `user:manage:blocked_users`, `user:read:subscriptions` and `user:read:follows`
+- Implemented [OAuth Authorization Code Flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#oauth-authorization-code-flow) with `UserTokenBuilder`
+- Added a way to suggest or infer that an user token is never expiring, making `is_elapsed` return false and `expires_in` a bogus (max) duration.
+
 ### Changed
 
-* MSRV: 1.51
-* Made scope take `Cow<&'static str>`
-* Made fields `access_token`, `refresh_token`, `user_id` and `login` `pub` on `UserToken` and `AppAccessToken` (where applicable)
-* Fixed wrong scope `user:read:stream_key` -> `channel:read:stream_key`
-* BREAKING: changed `TwitchToken::expires` -> `TwitchToken::expires_in` to calculate current lifetime of token
+- MSRV: 1.51
+- Made scope take `Cow<&'static str>`
+- Made fields `access_token`, `refresh_token`, `user_id` and `login` `pub` on `UserToken` and `AppAccessToken` (where applicable)
+- Fixed wrong scope `user:read:stream_key` -> `channel:read:stream_key`
+- BREAKING: changed `TwitchToken::expires` -> `TwitchToken::expires_in` to calculate current lifetime of token
 
 ## End of Changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 [Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.8.0...Unreleased)
 
+### Breaking
+
+* Added new feature flag `client` that enables client specific functions. Without this feature,
+  `twitch_oauth2` will only provide non-async functions and
+  provide library users `http::Request`s and consume `http::Response`s.
+
 ## [v0.8.0] - 2022-08-27
 
 [Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.7.1...v0.8.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = []
-client = []
+client = ["dep:async-trait"]
 reqwest = ["dep:reqwest", "client"]
 surf_client_curl = ["surf", "surf/curl-client"]
 surf = ["dep:surf", "dep:http-types", "http-types?/hyperium_http", "client"]
@@ -24,7 +24,7 @@ thiserror = "1.0.29"
 displaydoc = "0.2.3"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
-async-trait = "0.1.51"
+async-trait = { version = "0.1.51", optional = true }
 http = "0.2.5"
 surf = { version = "2.3.1", optional = true, default-features = false }
 reqwest = { version = "0.11.4", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = []
-reqwest = ["dep:reqwest"]
-surf_client_curl = ["dep:surf", "surf/curl-client"]
-surf = ["dep:surf", "dep:http-types", "http-types?/hyperium_http"]
+client = []
+reqwest = ["dep:reqwest", "client"]
+surf_client_curl = ["surf", "surf/curl-client"]
+surf = ["dep:surf", "dep:http-types", "http-types?/hyperium_http", "client"]
 mock_api = []
-all = ["surf_client_curl", "dep:reqwest"]
+all = ["surf_client_curl", "reqwest"]
 
 [dependencies]
 thiserror = "1.0.29"

--- a/release.toml
+++ b/release.toml
@@ -9,6 +9,5 @@ pre-release-replacements = [
   {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}", prerelease=false},
   {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate\n\n[Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v{{version}}...Unreleased)", prerelease=false},
   {file="README.md", search="twitch_oauth2/[a-z0-9\\.-]+/twitch_oauth2", replace="{{crate_name}}/{{version}}/{{crate_name}}", prerelease=true},
-  {file="src/lib.rs", search="https://docs.rs/twitch_oauth2/[a-z0-9\\.-]+", replace="https://docs.rs/{{crate_name}}/{{version}}", prerelease=true},
   {file="Cargo.toml", search="https://docs.rs/twitch_oauth2/[a-z0-9\\.-]+", replace="https://docs.rs/{{crate_name}}/{{version}}", prerelease=true},
 ]

--- a/src/id.rs
+++ b/src/id.rs
@@ -29,9 +29,9 @@ pub struct TwitchTokenResponse {
 impl TwitchTokenResponse {
     /// Create a [TwitchTokenResponse] from a [http::Response]
     pub fn from_response<B: AsRef<[u8]>>(
-        resp: &http::Response<B>,
+        response: &http::Response<B>,
     ) -> Result<TwitchTokenResponse, RequestParseError> {
-        crate::parse_response(resp)
+        crate::parse_response(response)
     }
 }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -2,9 +2,14 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::AccessToken;
+use crate::{AccessToken, RequestParseError};
 use std::time::Duration;
 /// Twitch's representation of the oauth flow.
+///
+/// Retrieve with
+///
+/// * [`UserTokenBuilder::get_user_token_request`](crate::tokens::UserTokenBuilder::get_user_token_request)
+/// * [`AppAccessToken::::get_app_access_token_request`](crate::tokens::AppAccessToken::get_app_access_token_request)
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TwitchTokenResponse {
     /// Access token
@@ -19,6 +24,15 @@ pub struct TwitchTokenResponse {
     #[serde(rename = "scope", deserialize_with = "scope::deserialize")]
     #[serde(default)]
     pub scopes: Option<Vec<crate::Scope>>,
+}
+
+impl TwitchTokenResponse {
+    /// Create a [TwitchTokenResponse] from a [http::Response]
+    pub fn from_response<B: AsRef<[u8]>>(
+        resp: &http::Response<B>,
+    ) -> Result<TwitchTokenResponse, RequestParseError> {
+        crate::parse_response(resp)
+    }
 }
 
 /// Twitch's representation of the oauth flow for errors

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -32,7 +32,7 @@ pub enum BearerTokenType {
 }
 
 /// Trait for twitch tokens to get fields and generalize over [AppAccessToken] and [UserToken]
-#[async_trait::async_trait]
+#[cfg_attr(feature = "client", async_trait::async_trait)]
 pub trait TwitchToken {
     /// Get the type of token.
     fn token_type() -> BearerTokenType;
@@ -120,7 +120,7 @@ pub trait TwitchToken {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "client", async_trait::async_trait)]
 impl<T: TwitchToken + Send> TwitchToken for Box<T> {
     fn token_type() -> BearerTokenType { T::token_type() }
 

--- a/src/tokens/app_access_token.rs
+++ b/src/tokens/app_access_token.rs
@@ -131,7 +131,7 @@ impl AppAccessToken {
             validated.client_id,
             client_secret,
             validated.scopes,
-            Some(validated.expires_in),
+            validated.expires_in,
         ))
     }
 

--- a/src/tokens/app_access_token.rs
+++ b/src/tokens/app_access_token.rs
@@ -1,10 +1,15 @@
 use twitch_types::{UserIdRef, UserNameRef};
 
+#[cfg(feature = "client")]
 use super::errors::{AppAccessTokenError, ValidationError};
+#[cfg(feature = "client")]
+use crate::client::Client;
+#[cfg(feature = "client")]
+use crate::tokens::errors::RefreshTokenError;
+use crate::tokens::{Scope, TwitchToken};
 use crate::{
-    client::Client,
-    tokens::{errors::RefreshTokenError, Scope, TwitchToken},
     types::{AccessToken, ClientId, ClientSecret, RefreshToken},
+    ClientIdRef, ClientSecretRef,
 };
 
 /// An App Access Token from the [OAuth client credentials flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-client-credentials-flow)
@@ -53,6 +58,7 @@ impl TwitchToken for AppAccessToken {
 
     fn user_id(&self) -> Option<&UserIdRef> { None }
 
+    #[cfg(feature = "client")]
     async fn refresh_token<'a, C>(
         &mut self,
         http_client: &'a C,
@@ -60,13 +66,14 @@ impl TwitchToken for AppAccessToken {
     where
         C: Client<'a>,
     {
-        let (access_token, expires_in, refresh_token) = if let Some(token) =
-            self.refresh_token.take()
-        {
-            crate::refresh_token(http_client, &token, &self.client_id, &self.client_secret).await?
-        } else {
-            return Err(RefreshTokenError::NoRefreshToken);
-        };
+        let (access_token, expires_in, refresh_token) =
+            if let Some(token) = self.refresh_token.take() {
+                token
+                    .refresh_token(http_client, &self.client_id, &self.client_secret)
+                    .await?
+            } else {
+                return Err(RefreshTokenError::NoRefreshToken);
+            };
         self.access_token = access_token;
         self.expires_in = expires_in;
         self.refresh_token = refresh_token;
@@ -106,6 +113,7 @@ impl AppAccessToken {
     }
 
     /// Assemble token and validate it. Retrieves [`client_id`](TwitchToken::client_id) and [`scopes`](TwitchToken::scopes).
+    #[cfg(feature = "client")]
     pub async fn from_existing<'a, RE, C>(
         http_client: &'a C,
         access_token: AccessToken,
@@ -116,7 +124,7 @@ impl AppAccessToken {
         C: Client<'a>,
     {
         let token = access_token;
-        let validated = crate::validate_token(http_client, &token).await?;
+        let validated = token.validate_token(http_client).await?;
         Ok(Self::from_existing_unchecked(
             token,
             refresh_token.into(),
@@ -127,7 +135,24 @@ impl AppAccessToken {
         ))
     }
 
+    /// Assemble token from twitch responses.
+    pub fn from_response(
+        response: crate::id::TwitchTokenResponse,
+        client_id: impl Into<ClientId>,
+        client_secret: impl Into<ClientSecret>,
+    ) -> AppAccessToken {
+        AppAccessToken::from_existing_unchecked(
+            response.access_token,
+            response.refresh_token,
+            client_id.into(),
+            client_secret,
+            response.scopes,
+            response.expires_in.map(std::time::Duration::from_secs),
+        )
+    }
+
     /// Generate app access token via [OAuth client credentials flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-client-credentials-flow)
+    #[cfg(feature = "client")]
     pub async fn get_app_access_token<'a, C>(
         http_client: &'a C,
         client_id: ClientId,
@@ -137,7 +162,35 @@ impl AppAccessToken {
     where
         C: Client<'a>,
     {
-        // FIXME: self.client.exchange_code(code) does not work as oauth2 currently only sends it in body as per spec, but twitch uses query params.
+        let req = Self::get_app_access_token_request(&client_id, &client_secret, scopes);
+
+        let resp = http_client
+            .req(req)
+            .await
+            .map_err(AppAccessTokenError::Request)?;
+
+        let response = crate::id::TwitchTokenResponse::from_response(&resp)?;
+        let expires_in = response.expires_in();
+        let app_access = AppAccessToken::from_existing_unchecked(
+            response.access_token,
+            response.refresh_token,
+            client_id,
+            client_secret,
+            response.scopes,
+            expires_in,
+        );
+
+        Ok(app_access)
+    }
+
+    /// Get the request for getting a app access token.
+    ///
+    /// Parse with [TwitchTokenResponse::from_response](crate::id::TwitchTokenResponse::from_response) and [AppAccessToken::from_response]
+    pub fn get_app_access_token_request(
+        client_id: &ClientIdRef,
+        client_secret: &ClientSecretRef,
+        scopes: Vec<Scope>,
+    ) -> http::Request<Vec<u8>> {
         use http::{HeaderMap, Method};
         use std::collections::HashMap;
         let scope: String = scopes
@@ -151,30 +204,12 @@ impl AppAccessToken {
         params.insert("grant_type", "client_credentials");
         params.insert("scope", &scope);
 
-        let req = crate::construct_request(
+        crate::construct_request(
             &crate::TOKEN_URL,
             &params,
             HeaderMap::new(),
             Method::POST,
             vec![],
-        );
-
-        let resp = http_client
-            .req(req)
-            .await
-            .map_err(AppAccessTokenError::Request)?;
-
-        let response: crate::id::TwitchTokenResponse = crate::parse_response(&resp)?;
-        let expires_in = response.expires_in();
-        let app_access = AppAccessToken::from_existing_unchecked(
-            response.access_token,
-            response.refresh_token,
-            client_id,
-            client_secret,
-            response.scopes,
-            expires_in,
-        );
-
-        Ok(app_access)
+        )
     }
 }

--- a/src/tokens/app_access_token.rs
+++ b/src/tokens/app_access_token.rs
@@ -46,7 +46,7 @@ impl std::fmt::Debug for AppAccessToken {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "client", async_trait::async_trait)]
 impl TwitchToken for AppAccessToken {
     fn token_type() -> super::BearerTokenType { super::BearerTokenType::AppAccessToken }
 

--- a/src/tokens/app_access_token.rs
+++ b/src/tokens/app_access_token.rs
@@ -141,13 +141,14 @@ impl AppAccessToken {
         client_id: impl Into<ClientId>,
         client_secret: impl Into<ClientSecret>,
     ) -> AppAccessToken {
+        let expires_in = response.expires_in();
         AppAccessToken::from_existing_unchecked(
             response.access_token,
             response.refresh_token,
             client_id.into(),
             client_secret,
             response.scopes,
-            response.expires_in.map(std::time::Duration::from_secs),
+            expires_in,
         )
     }
 
@@ -170,15 +171,7 @@ impl AppAccessToken {
             .map_err(AppAccessTokenError::Request)?;
 
         let response = crate::id::TwitchTokenResponse::from_response(&resp)?;
-        let expires_in = response.expires_in();
-        let app_access = AppAccessToken::from_existing_unchecked(
-            response.access_token,
-            response.refresh_token,
-            client_id,
-            client_secret,
-            response.scopes,
-            expires_in,
-        );
+        let app_access = AppAccessToken::from_response(response, client_id, client_secret);
 
         Ok(app_access)
     }

--- a/src/tokens/errors.rs
+++ b/src/tokens/errors.rs
@@ -3,6 +3,7 @@
 /// General errors for talking with twitch, used in [AppAccessToken::get_app_access_token][crate::tokens::AppAccessToken::get_app_access_token]
 #[allow(missing_docs)]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
+#[cfg(feature = "client")]
 pub enum AppAccessTokenError<RE: std::error::Error + Send + Sync + 'static> {
     /// request for token failed
     Request(#[source] RE),
@@ -10,7 +11,7 @@ pub enum AppAccessTokenError<RE: std::error::Error + Send + Sync + 'static> {
     RequestParseError(#[from] crate::RequestParseError),
 }
 
-/// Errors for [validate_token][crate::validate_token]
+/// Errors for [AccessToken::validate_token][crate::AccessTokenRef::validate_token] and [UserToken::from_response][crate::tokens::UserToken::from_response]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 pub enum ValidationError<RE: std::error::Error + Send + Sync + 'static> {
     /// token is not authorized for use
@@ -24,9 +25,22 @@ pub enum ValidationError<RE: std::error::Error + Send + Sync + 'static> {
     NoLogin,
 }
 
-/// Errors for [revoke_token][crate::revoke_token]
+impl ValidationError<std::convert::Infallible> {
+    /// Convert this error from a infallible to another
+    pub fn into_other<RE: std::error::Error + Send + Sync + 'static>(self) -> ValidationError<RE> {
+        match self {
+            ValidationError::NotAuthorized => ValidationError::NotAuthorized,
+            ValidationError::RequestParseError(e) => ValidationError::RequestParseError(e),
+            ValidationError::NoLogin => ValidationError::NoLogin,
+            ValidationError::Request(_) => unreachable!(),
+        }
+    }
+}
+
+/// Errors for [AccessToken::revoke_token][crate::AccessTokenRef::revoke_token]
 #[allow(missing_docs)]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
+#[cfg(feature = "client")]
 pub enum RevokeTokenError<RE: std::error::Error + Send + Sync + 'static> {
     /// could not parse response when revoking token
     RequestParseError(#[from] crate::RequestParseError),
@@ -37,6 +51,7 @@ pub enum RevokeTokenError<RE: std::error::Error + Send + Sync + 'static> {
 /// Errors for [TwitchToken::refresh_token][crate::TwitchToken::refresh_token]
 #[allow(missing_docs)]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
+#[cfg(feature = "client")]
 pub enum RefreshTokenError<RE: std::error::Error + Send + Sync + 'static> {
     /// request when refreshing token failed
     RequestError(#[source] RE),
@@ -54,6 +69,7 @@ pub enum RefreshTokenError<RE: std::error::Error + Send + Sync + 'static> {
 
 /// Errors for [`UserTokenBuilder::get_user_token`](crate::tokens::UserTokenBuilder::get_user_token) and [`UserToken::mock_token`](crate::tokens::UserToken::mock_token)
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
+#[cfg(feature = "client")]
 pub enum UserTokenExchangeError<RE: std::error::Error + Send + Sync + 'static> {
     /// request for user token failed
     RequestError(#[source] RE),
@@ -67,6 +83,7 @@ pub enum UserTokenExchangeError<RE: std::error::Error + Send + Sync + 'static> {
 
 /// Errors for [ImplicitUserTokenBuilder::get_user_token][crate::tokens::ImplicitUserTokenBuilder::get_user_token]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
+#[cfg(feature = "client")]
 pub enum ImplicitUserTokenExchangeError<RE: std::error::Error + Send + Sync + 'static> {
     // FIXME: should be TwitchTokenErrorResponse
     /// twitch returned an error: {error:?} - {description:?}

--- a/src/tokens/user_token.rs
+++ b/src/tokens/user_token.rs
@@ -229,7 +229,7 @@ impl UserToken {
     pub fn set_secret(&mut self, secret: Option<ClientSecret>) { self.client_secret = secret }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "client", async_trait::async_trait)]
 impl TwitchToken for UserToken {
     fn token_type() -> super::BearerTokenType { super::BearerTokenType::UserToken }
 


### PR DESCRIPTION
Enables usage of the crate only as a parser + types

The client specific functions are now enabled via the `client` feature.

This enables more specific handling of the http requests and makes testing easier.