### PR TITLE
Implement validator to check if token has the correct scopes

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -6,3 +6,4 @@ use_field_init_shorthand = true
 reorder_impl_items = true
 edition = "2018"
 newline_style = "Unix"
+format_code_in_doc_comments = true

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,4 @@
 //! Provides different http clients
-//!
 
 // This module is heavily inspired (read: copied) by twitch_api2::client.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ use id::TwitchTokenErrorResponse;
 use tokens::errors::{RefreshTokenError, RevokeTokenError, ValidationError};
 
 #[doc(inline)]
-pub use scopes::Scope;
+pub use scopes::{Scope, Validator};
 #[doc(inline)]
 pub use tokens::{AppAccessToken, TwitchToken, UserToken, ValidatedToken};
 

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -1,4 +1,7 @@
 //! Module for all possible scopes in twitch.
+pub mod validator;
+pub use validator::Validator;
+
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -218,7 +218,7 @@ scope_impls!(
 );
 
 impl Scope {
-    /// Get the scope as validator
+    /// Get the scope as a [validator](Validator).
     pub const fn to_validator(self) -> Validator { Validator::scope(self) }
 }
 

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -217,6 +217,11 @@ scope_impls!(
     WhispersRead,                   scope: "whispers:read",                     doc: "View your whisper messages.";
 );
 
+impl Scope {
+    /// Get the scope as validator
+    pub const fn to_validator(self) -> Validator { Validator::scope(self) }
+}
+
 impl std::borrow::Borrow<str> for Scope {
     fn borrow(&self) -> &str { self.as_str() }
 }

--- a/src/scopes/validator.rs
+++ b/src/scopes/validator.rs
@@ -5,21 +5,24 @@ use super::Scope;
 
 pub type Validators = Cow<'static, [Validator]>;
 
+/// A [validator](Validator) is a way to check if an array of scopes matches a predicate.
+///
+/// Can be constructed easily with the [validator!](crate::validator) macro.
 #[derive(Clone)]
 pub enum Validator {
-    Scope(Scope, bool),
-    And(Sized<Validators>, bool),
-    Or(Sized<Validators>, bool),
+    Scope(Scope),
+    All(Sized<Validators>),
+    Any(Sized<Validators>),
+    Not(Sized<Validators>),
 }
 
 impl std::fmt::Debug for Validator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Validator::Scope(scope, _) => scope.fmt(f),
-            Validator::And(Sized(and), false) => f.debug_tuple("And").field(and).finish(),
-            Validator::And(Sized(and), true) => f.debug_tuple("NotAnd").field(and).finish(),
-            Validator::Or(Sized(or), false) => f.debug_tuple("Or").field(or).finish(),
-            Validator::Or(Sized(or), true) => f.debug_tuple("NotOr").field(or).finish(),
+            Validator::Scope(scope) => scope.fmt(f),
+            Validator::All(Sized(all)) => f.debug_tuple("All").field(all).finish(),
+            Validator::Any(Sized(any)) => f.debug_tuple("Any").field(any).finish(),
+            Validator::Not(Sized(not)) => f.debug_tuple("Not").field(not).finish(),
         }
     }
 }
@@ -28,116 +31,255 @@ impl Validator {
     #[must_use]
     pub fn matches(&self, scopes: &[Scope]) -> bool {
         match &self {
-            Validator::Scope(scope, _) => scopes.contains(scope),
-            Validator::And(Sized(validators), neg) => {
-                validators.iter().all(|v| v.matches(scopes)) ^ neg
-            }
-            Validator::Or(Sized(validators), neg) => {
-                validators.iter().any(|v| v.matches(scopes)) ^ neg
-            }
+            Validator::Scope(scope) => scopes.contains(scope),
+            Validator::All(Sized(validators)) => validators.iter().all(|v| v.matches(scopes)),
+            Validator::Any(Sized(validators)) => validators.iter().any(|v| v.matches(scopes)),
+            Validator::Not(Sized(validator)) => !validator.iter().any(|v| v.matches(scopes)),
         }
     }
 
-    pub const fn scope(scope: Scope) -> Self { Validator::Scope(scope, false) }
+    pub const fn scope(scope: Scope) -> Self { Validator::Scope(scope) }
 
-    pub const fn and_multiple(ands: &'static [Validator]) -> Self {
-        Validator::And(Sized(Cow::Borrowed(ands)), false)
+    pub const fn all_multiple(ands: &'static [Validator]) -> Self {
+        Validator::All(Sized(Cow::Borrowed(ands)))
     }
 
-    pub const fn or_multiple(ands: &'static [Validator]) -> Self {
-        Validator::Or(Sized(Cow::Borrowed(ands)), false)
+    pub const fn any_multiple(anys: &'static [Validator]) -> Self {
+        Validator::Any(Sized(Cow::Borrowed(anys)))
     }
+
+    pub const fn not(not: &'static Validator) -> Self {
+        Validator::Not(Sized(Cow::Borrowed(std::slice::from_ref(not))))
+    }
+
+    pub const fn to_validator(self) -> Self { self }
 }
-
 
 // https://github.com/rust-lang/rust/issues/47032#issuecomment-568784919
 #[derive(Debug, Clone)]
 #[repr(transparent)]
-pub struct Sized<T>(T);
-
-impl std::ops::Not for Validator {
-    type Output = Self;
-
-    fn not(self) -> Self::Output {
-        match self {
-            Validator::Scope(s, b) => Validator::Scope(s, !b),
-            Validator::And(s, b) => Validator::And(s, !b),
-            Validator::Or(s, b) => Validator::Or(s, !b),
-        }
-    }
-}
+pub struct Sized<T>(pub T);
 
 impl From<Scope> for Validator {
     fn from(scope: Scope) -> Self { Validator::scope(scope) }
 }
 
-/// Syntax should be
+/// A [validator](Validator) is a way to check if a slice of scopes matches a predicate.
+///
+/// Uses a functional style to compose the predicate. Can be used in const context.
+///
+/// # Supported operators
+///
+/// * `not(...)`
+///   * negates the validator passed inside, can only take one argument
+/// * `all(...)`
+///   * returns true if all validators passed inside return true
+/// * `any(...)`
+///   * returns true if **any** validator passed inside returns true
+///
+/// # Examples
+///
+/// ## Multiple scopes
+///
 /// ```rust
 /// use twitch_oauth2::{Scope, validator};
 /// let scopes: &[Scope] = &[Scope::ChatEdit, Scope::ChatRead];
 /// let validator = validator!(Scope::ChatEdit, Scope::ChatRead);
-///    assert!(validator.matches(scopes));
+/// assert!(validator.matches(scopes));
+/// assert!(!validator.matches(&scopes[..1]));
 /// ```
+///
+/// ## Multiple scopes with explicit all(...)
 ///
 /// ```rust
 /// use twitch_oauth2::{Scope, validator};
 /// let scopes: &[Scope] = &[Scope::ChatEdit, Scope::ChatRead];
-/// let validator = validator!(and(Scope::ChatEdit, Scope::ChatRead));
-///    assert!(validator.matches(scopes));
+/// let validator = validator!(all(Scope::ChatEdit, Scope::ChatRead));
+/// assert!(validator.matches(scopes));
+/// assert!(!validator.matches(&scopes[..1]));
 /// ```
+///
+/// ## Multiple scopes with nested any(...)
 ///
 /// ```rust
 /// use twitch_oauth2::{Scope, validator};
 /// let scopes: &[Scope] = &[Scope::ChatEdit, Scope::ChatRead];
-/// let validator = validator!(and(Scope::ChatEdit, or(Scope::ChatRead, Scope::ChannelReadSubscriptions)));
-///    assert!(validator.matches(scopes));
+/// let validator = validator!(Scope::ChatEdit, any(Scope::ChatRead, Scope::ChannelReadSubscriptions));
+/// assert!(validator.matches(scopes));
+/// assert!(!validator.matches(&scopes[1..]));
+/// ```
+///
+/// ## Not
+///
+/// ```rust
+/// use twitch_oauth2::{Scope, validator};
+/// let scopes: &[Scope] = &[Scope::ChatRead];
+/// let validator = validator!(not(Scope::ChatEdit));
+/// assert!(validator.matches(scopes));
+/// ```
+///
+/// ## Combining other validators
+///
+/// ```
+/// use twitch_oauth2::{Scope, Validator, validator};
+/// let scopes: &[Scope] = &[Scope::ChatEdit, Scope::ChatRead, Scope::ModeratorManageAutoMod, Scope::ModerationRead];
+/// const CHAT_SCOPES: Validator = validator!(all(Scope::ChatEdit, Scope::ChatRead));
+/// const MODERATOR_SCOPES: Validator = validator!(Scope::ModerationRead, Scope::ModeratorManageAutoMod);
+/// const COMBINED: Validator = validator!(CHAT_SCOPES, MODERATOR_SCOPES);
+/// assert!(COMBINED.matches(scopes));
+/// assert!(!COMBINED.matches(&scopes[1..]));
+/// ```
+///
+/// ## Invalid examples
+///
+/// ### Invalid usage of not(...)
+///
+/// ```compile_fail
+/// use twitch_oauth2::{Scope, validator};
+/// let scopes: &[Scope] = &[Scope::ChatEdit, Scope::ChatRead];
+/// let validator = validator!(not(Scope::ChatEdit, Scope::ChatRead));
+/// assert!(validator.matches(scopes));
+/// ```
+///
+/// ### Invalid operator
+///
+/// ```compile_fail
+/// use twitch_oauth2::{Scope, validator};
+/// let scopes: &[Scope] = &[Scope::ChatEdit, Scope::ChatRead];
+/// let validator = validator!(xor(Scope::ChatEdit, Scope::ChatRead));
+/// assert!(validator.matches(scopes));
 /// ```
 #[macro_export]
 macro_rules! validator {
-    (@and $($scope:tt),+) => {{
-        static MULT: &[$crate::scopes::Validator] = &[$(validator!($scope)),*];
-        $crate::scopes::Validator::and_multiple(MULT)
+    ($operator:ident($($scopes:tt)+)) => {{
+        $crate::validator_logic!(@$operator $($scopes)*)
     }};
-    (@or $($scope:tt),+) => {{
-        static MULT: &[$crate::scopes::Validator] = &[$(validator!($scope)),*];
-        $crate::scopes::Validator::or_multiple(MULT)
+    ($scope:expr $(,)?) => {{
+        $scope.to_validator()
     }};
-    // Replacing these with tt doesn't work
-    (and($($and:tt),+)) => {{
-        validator!(@and $($and),*)
-    }};
-    (or($($or:tt),+)) => {{
-        validator!(@or $($or)*)
-    }};
-    ($scope:expr) => {{
-        $crate::scopes::Validator::scope($scope)
-    }};
-    ($scope:expr,) => {{
-        $crate::scopes::Validator::scope($scope)
-    }};
-    ($($scope:tt),+) => {{
-        validator!(and($($scope),*))
+    ($($all:tt)+) => {{
+        $crate::validator_logic!(@all $($all)*)
     }};
 }
 
+/// Logical operators for the [validator!] macro.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! validator_logic {
+    (@all $($scope:tt)+) => {{
+        const MULT: &[$crate::Validator] = &$crate::validator_accumulate![@down [] $($scope)*];
+        $crate::Validator::all_multiple(MULT)
+    }};
+    (@any $($scope:tt)+) => {{
+        const MULT: &[$crate::Validator] = &$crate::validator_accumulate![@down [] $($scope)*];
+        $crate::Validator::any_multiple(MULT)
+    }};
+    (@not $($scope:tt)+) => {{
+        $crate::validator_logic!(@notend $($scope)*);
+        const NOT: &[$crate::Validator] = &[$crate::validator!($($scope)*)];
+        $crate::Validator::not(&NOT[0])
+    }};
+    (@notend $e:expr) => {};
+    (@notend $e:expr, $($t:tt)*) => {compile_error!("not(...) takes only one argument")};
+    (@$operator:ident $($rest:tt)*) => {
+        compile_error!(concat!("unknown operator `", stringify!($operator), "`, only `all`, `any` and `not` are supported"))
+    }
+}
 
-//#[cfg(test)]
+/// Accumulator for the [validator!] macro.
+///
+// Thanks to danielhenrymantilla, the macro wizard
+#[doc(hidden)]
+#[macro_export]
+macro_rules! validator_accumulate {
+    // inner operator
+    (@down
+        [$($acc:tt)*]
+        $operator:ident($($all:tt)*) $(, $($rest:tt)* )?
+    ) => (
+        $crate::validator_accumulate![@down
+            [$($acc)* $crate::validator!($operator($($all)*)),]
+            $($($rest)*)?
+        ]
+    );
+    // inner scope
+    (@down
+        [$($acc:tt)*]
+        $scope:expr $(, $($rest:tt)* )?
+    ) => (
+        $crate::validator_accumulate![@down
+            [$($acc)* $crate::validator!($scope),]
+            $($($rest)*)?
+        ]
+    );
+    // nothing left
+    (@down
+        [$($output:tt)*] $(,)?
+    ) => (
+        [ $($output)* ]
+    );
+}
+
+#[cfg(test)]
 mod tests {
+    use super::*;
     use crate::Scope;
 
-    use super::*;
+    #[test]
     fn valid_basic() {
         let scopes = &[Scope::ChatEdit, Scope::ChatRead];
-        let validator = validator!(and(Scope::ChatEdit, Scope::ChatRead));
-        dbg!(&validator);
-        assert!(validator.matches(scopes));
+        const VALIDATOR: Validator = validator!(Scope::ChatEdit, Scope::ChatRead);
+        dbg!(&VALIDATOR);
+        assert!(VALIDATOR.matches(scopes));
+    }
+
+    #[test]
+    fn valid_all() {
+        let scopes = &[Scope::ChatEdit, Scope::ChatRead];
+        const VALIDATOR: Validator = validator!(all(Scope::ChatEdit, Scope::ChatRead));
+        dbg!(&VALIDATOR);
+        assert!(VALIDATOR.matches(scopes));
+    }
+
+    #[test]
+    fn valid_any() {
+        let scopes = &[Scope::ChatEdit, Scope::ModerationRead];
+        const VALIDATOR: Validator =
+            validator!(Scope::ChatEdit, any(Scope::ChatRead, Scope::ModerationRead));
+        dbg!(&VALIDATOR);
+        assert!(VALIDATOR.matches(scopes));
+    }
+
+    #[test]
+    fn valid_not() {
+        let scopes = &[Scope::ChannelEditCommercial, Scope::ChatRead];
+        const VALIDATOR: Validator = validator!(not(Scope::ChatEdit));
+        dbg!(&VALIDATOR);
+        assert!(VALIDATOR.matches(scopes));
+    }
+
+    #[test]
+    fn valid_strange() {
+        let scopes = &[Scope::ChatEdit, Scope::ModerationRead, Scope::UserEdit];
+        let scopes_1 = &[Scope::ChatEdit, Scope::ChatRead];
+        const VALIDATOR: Validator = validator!(
+            Scope::ChatEdit,
+            any(Scope::ChatRead, all(Scope::ModerationRead, Scope::UserEdit))
+        );
+        dbg!(&VALIDATOR);
+        assert!(VALIDATOR.matches(scopes));
+        assert!(VALIDATOR.matches(scopes_1));
     }
     #[test]
-    fn valid_and() {
-       let scopes = &[Scope::ChatEdit, Scope::ChatRead];
-       let validator = validator!(and(Scope::ChatEdit, Scope::ChatRead));
-       dbg!(&validator);
-       assert!(validator.matches(scopes));
+    fn valid_strange_not() {
+        let scopes = &[Scope::ModerationRead, Scope::UserEdit];
+        let scopes_1 = &[Scope::ChatEdit, Scope::ChatRead];
+        const VALIDATOR: Validator = validator!(
+            not(Scope::ChatEdit),
+            any(Scope::ChatRead, all(Scope::ModerationRead, Scope::UserEdit))
+        );
+        dbg!(&VALIDATOR);
+        assert!(VALIDATOR.matches(scopes));
+        assert!(!VALIDATOR.matches(scopes_1));
     }
 }
-

--- a/src/scopes/validator.rs
+++ b/src/scopes/validator.rs
@@ -82,7 +82,7 @@ impl From<Scope> for Validator {
 /// ## Multiple scopes
 ///
 /// ```rust
-/// use twitch_oauth2::{Scope, validator};
+/// use twitch_oauth2::{validator, Scope};
 /// let scopes: &[Scope] = &[Scope::ChatEdit, Scope::ChatRead];
 /// let validator = validator!(Scope::ChatEdit, Scope::ChatRead);
 /// assert!(validator.matches(scopes));
@@ -92,7 +92,7 @@ impl From<Scope> for Validator {
 /// ## Multiple scopes with explicit all(...)
 ///
 /// ```rust
-/// use twitch_oauth2::{Scope, validator};
+/// use twitch_oauth2::{validator, Scope};
 /// let scopes: &[Scope] = &[Scope::ChatEdit, Scope::ChatRead];
 /// let validator = validator!(all(Scope::ChatEdit, Scope::ChatRead));
 /// assert!(validator.matches(scopes));
@@ -102,9 +102,12 @@ impl From<Scope> for Validator {
 /// ## Multiple scopes with nested any(...)
 ///
 /// ```rust
-/// use twitch_oauth2::{Scope, validator};
+/// use twitch_oauth2::{validator, Scope};
 /// let scopes: &[Scope] = &[Scope::ChatEdit, Scope::ChatRead];
-/// let validator = validator!(Scope::ChatEdit, any(Scope::ChatRead, Scope::ChannelReadSubscriptions));
+/// let validator = validator!(
+///     Scope::ChatEdit,
+///     any(Scope::ChatRead, Scope::ChannelReadSubscriptions)
+/// );
 /// assert!(validator.matches(scopes));
 /// assert!(!validator.matches(&scopes[1..]));
 /// ```
@@ -112,7 +115,7 @@ impl From<Scope> for Validator {
 /// ## Not
 ///
 /// ```rust
-/// use twitch_oauth2::{Scope, validator};
+/// use twitch_oauth2::{validator, Scope};
 /// let scopes: &[Scope] = &[Scope::ChatRead];
 /// let validator = validator!(not(Scope::ChatEdit));
 /// assert!(validator.matches(scopes));
@@ -121,10 +124,16 @@ impl From<Scope> for Validator {
 /// ## Combining other validators
 ///
 /// ```
-/// use twitch_oauth2::{Scope, Validator, validator};
-/// let scopes: &[Scope] = &[Scope::ChatEdit, Scope::ChatRead, Scope::ModeratorManageAutoMod, Scope::ModerationRead];
+/// use twitch_oauth2::{validator, Scope, Validator};
+/// let scopes: &[Scope] = &[
+///     Scope::ChatEdit,
+///     Scope::ChatRead,
+///     Scope::ModeratorManageAutoMod,
+///     Scope::ModerationRead,
+/// ];
 /// const CHAT_SCOPES: Validator = validator!(all(Scope::ChatEdit, Scope::ChatRead));
-/// const MODERATOR_SCOPES: Validator = validator!(Scope::ModerationRead, Scope::ModeratorManageAutoMod);
+/// const MODERATOR_SCOPES: Validator =
+///     validator!(Scope::ModerationRead, Scope::ModeratorManageAutoMod);
 /// const COMBINED: Validator = validator!(CHAT_SCOPES, MODERATOR_SCOPES);
 /// assert!(COMBINED.matches(scopes));
 /// assert!(!COMBINED.matches(&scopes[1..]));
@@ -187,7 +196,6 @@ macro_rules! validator_logic {
 }
 
 /// Accumulator for the [validator!] macro.
-///
 // Thanks to danielhenrymantilla, the macro wizard
 #[doc(hidden)]
 #[macro_export]

--- a/src/scopes/validator.rs
+++ b/src/scopes/validator.rs
@@ -1,0 +1,143 @@
+#![allow(missing_docs)]
+use std::borrow::Cow;
+
+use super::Scope;
+
+pub type Validators = Cow<'static, [Validator]>;
+
+#[derive(Clone)]
+pub enum Validator {
+    Scope(Scope, bool),
+    And(Sized<Validators>, bool),
+    Or(Sized<Validators>, bool),
+}
+
+impl std::fmt::Debug for Validator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Validator::Scope(scope, _) => scope.fmt(f),
+            Validator::And(Sized(and), false) => f.debug_tuple("And").field(and).finish(),
+            Validator::And(Sized(and), true) => f.debug_tuple("NotAnd").field(and).finish(),
+            Validator::Or(Sized(or), false) => f.debug_tuple("Or").field(or).finish(),
+            Validator::Or(Sized(or), true) => f.debug_tuple("NotOr").field(or).finish(),
+        }
+    }
+}
+
+impl Validator {
+    #[must_use]
+    pub fn matches(&self, scopes: &[Scope]) -> bool {
+        match &self {
+            Validator::Scope(scope, _) => scopes.contains(scope),
+            Validator::And(Sized(validators), neg) => {
+                validators.iter().all(|v| v.matches(scopes)) ^ neg
+            }
+            Validator::Or(Sized(validators), neg) => {
+                validators.iter().any(|v| v.matches(scopes)) ^ neg
+            }
+        }
+    }
+
+    pub const fn scope(scope: Scope) -> Self { Validator::Scope(scope, false) }
+
+    pub const fn and_multiple(ands: &'static [Validator]) -> Self {
+        Validator::And(Sized(Cow::Borrowed(ands)), false)
+    }
+
+    pub const fn or_multiple(ands: &'static [Validator]) -> Self {
+        Validator::Or(Sized(Cow::Borrowed(ands)), false)
+    }
+}
+
+
+// https://github.com/rust-lang/rust/issues/47032#issuecomment-568784919
+#[derive(Debug, Clone)]
+#[repr(transparent)]
+pub struct Sized<T>(T);
+
+impl std::ops::Not for Validator {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        match self {
+            Validator::Scope(s, b) => Validator::Scope(s, !b),
+            Validator::And(s, b) => Validator::And(s, !b),
+            Validator::Or(s, b) => Validator::Or(s, !b),
+        }
+    }
+}
+
+impl From<Scope> for Validator {
+    fn from(scope: Scope) -> Self { Validator::scope(scope) }
+}
+
+/// Syntax should be
+/// ```rust
+/// use twitch_oauth2::{Scope, validator};
+/// let scopes: &[Scope] = &[Scope::ChatEdit, Scope::ChatRead];
+/// let validator = validator!(Scope::ChatEdit, Scope::ChatRead);
+///    assert!(validator.matches(scopes));
+/// ```
+///
+/// ```rust
+/// use twitch_oauth2::{Scope, validator};
+/// let scopes: &[Scope] = &[Scope::ChatEdit, Scope::ChatRead];
+/// let validator = validator!(and(Scope::ChatEdit, Scope::ChatRead));
+///    assert!(validator.matches(scopes));
+/// ```
+///
+/// ```rust
+/// use twitch_oauth2::{Scope, validator};
+/// let scopes: &[Scope] = &[Scope::ChatEdit, Scope::ChatRead];
+/// let validator = validator!(and(Scope::ChatEdit, or(Scope::ChatRead, Scope::ChannelReadSubscriptions)));
+///    assert!(validator.matches(scopes));
+/// ```
+#[macro_export]
+macro_rules! validator {
+    (@and $($scope:tt),+) => {{
+        static MULT: &[$crate::scopes::Validator] = &[$(validator!($scope)),*];
+        $crate::scopes::Validator::and_multiple(MULT)
+    }};
+    (@or $($scope:tt),+) => {{
+        static MULT: &[$crate::scopes::Validator] = &[$(validator!($scope)),*];
+        $crate::scopes::Validator::or_multiple(MULT)
+    }};
+    // Replacing these with tt doesn't work
+    (and($($and:tt),+)) => {{
+        validator!(@and $($and),*)
+    }};
+    (or($($or:tt),+)) => {{
+        validator!(@or $($or)*)
+    }};
+    ($scope:expr) => {{
+        $crate::scopes::Validator::scope($scope)
+    }};
+    ($scope:expr,) => {{
+        $crate::scopes::Validator::scope($scope)
+    }};
+    ($($scope:tt),+) => {{
+        validator!(and($($scope),*))
+    }};
+}
+
+
+//#[cfg(test)]
+mod tests {
+    use crate::Scope;
+
+    use super::*;
+    fn valid_basic() {
+        let scopes = &[Scope::ChatEdit, Scope::ChatRead];
+        let validator = validator!(and(Scope::ChatEdit, Scope::ChatRead));
+        dbg!(&validator);
+        assert!(validator.matches(scopes));
+    }
+    #[test]
+    fn valid_and() {
+       let scopes = &[Scope::ChatEdit, Scope::ChatRead];
+       let validator = validator!(and(Scope::ChatEdit, Scope::ChatRead));
+       dbg!(&validator);
+       assert!(validator.matches(scopes));
+    }
+}
+

--- a/src/tokens/user_token.rs
+++ b/src/tokens/user_token.rs
@@ -174,7 +174,8 @@ impl UserToken {
     ///     "mockclientsecret".into(),
     ///     "user_id",
     ///     vec![],
-    ///     ).await?;
+    /// )
+    /// .await?;
     /// # Ok(())}
     /// # fn main() {run();}
     /// ```
@@ -643,8 +644,6 @@ impl ImplicitUserTokenBuilder {
     /// </body>
     /// </html>
     /// ```
-    ///
-    ///
     #[cfg(feature = "client")]
     pub async fn get_user_token<'a, C>(
         self,


### PR DESCRIPTION
implements a way to validate a slice of scopes with a specific predicate

```rs
use twitch_oauth2::{validator, Scope, Validator};
let scopes: &[Scope] = &[
    Scope::ChatEdit,
    Scope::ChatRead,
    Scope::ModeratorManageAutoMod,
    Scope::ModerationRead,
];
const CHAT_SCOPES: Validator = validator!(all(Scope::ChatEdit, Scope::ChatRead));
const MODERATOR_SCOPES: Validator =
    validator!(Scope::ModerationRead, Scope::ModeratorManageAutoMod);
const COMBINED: Validator = validator!(CHAT_SCOPES, MODERATOR_SCOPES);
assert!(COMBINED.matches(scopes));
assert!(!COMBINED.matches(&scopes[1..]));
```