### PR TITLE
Update to http 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 [Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.12.9...Unreleased)
 
+### Changed
+
+- **BREAKING:** Updated `http` to `1.1.0` and `reqwest` to `0.12.2`
+
 ## [v0.12.9] - 2024-01-27
 
 [Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.12.8...v0.12.9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ## [Unreleased] - ReleaseDate
 
-[Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.12.9...Unreleased)
+[Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.13.0...Unreleased)
+
+## [v0.13.0] - 2024-04-04
+
+[Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.12.9...v0.13.0)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,16 +916,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
 dependencies = [
  "bytes 1.5.0",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 1.1.0",
  "indexmap",
  "slab",
  "tokio",
@@ -983,13 +983,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "0.4.6"
+name = "http"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes 1.5.0",
- "http",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes 1.5.0",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes 1.5.0",
+ "futures-core",
+ "http 1.1.0",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1019,7 +1042,7 @@ dependencies = [
  "base64 0.13.1",
  "cookie",
  "futures-lite 1.13.0",
- "http",
+ "http 0.2.11",
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
@@ -1037,46 +1060,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hyper"
-version = "0.14.28"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
 dependencies = [
  "bytes 1.5.0",
  "futures-channel",
- "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 1.1.0",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.5",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
  "want",
 ]
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes 1.5.0",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes 1.5.0",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2 0.5.5",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1149,7 +1185,7 @@ dependencies = [
  "curl-sys",
  "flume",
  "futures-lite 1.13.0",
- "http",
+ "http 0.2.11",
  "log",
  "once_cell",
  "slab",
@@ -1604,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.23"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
+checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
 dependencies = [
  "base64 0.21.7",
  "bytes 1.5.0",
@@ -1614,10 +1650,12 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 1.1.0",
  "http-body",
+ "http-body-util",
  "hyper",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -1626,9 +1664,11 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -1701,6 +1741,15 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.4.13",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -1874,6 +1923,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
 name = "socket2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2016,6 +2071,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "system-configuration"
@@ -2187,6 +2248,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,7 +2355,7 @@ dependencies = [
  "base64 0.21.7",
  "displaydoc",
  "dotenv",
- "http",
+ "http 1.1.0",
  "http-types",
  "once_cell",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,7 +2347,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twitch_oauth2"
-version = "0.12.9"
+version = "0.13.0"
 dependencies = [
  "aliri_braid",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ serde = { version = "1.0.163" }
 serde_derive = { version = "1.0.163" }
 serde_json = "1.0.96"
 async-trait = { version = "0.1.68", optional = true }
-http = "0.2.9"
+http = "1.1.0"
 surf = { version = "2.3.2", optional = true, default-features = false }
-reqwest = { version = "0.11.18", optional = true, default-features = false }
+reqwest = { version = "0.12.2", optional = true, default-features = false }
 http-types = { version = "2.12.0", optional = true }
 once_cell = "1.17.1"
 aliri_braid = "0.4.0"
@@ -54,7 +54,7 @@ tokio = { version = "1.28.2", features = [
 ] }
 dotenv = "0.15.0"
 anyhow = "1.0.71"
-reqwest = "0.11.18"
+reqwest = "0.12.2"
 surf = "2.3.2"
 rpassword = "7.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "twitch_oauth2"
-version = "0.12.9"
+version = "0.13.0"
 edition = "2021"
 repository = "https://github.com/twitch-rs/twitch_oauth2"
 license = "MIT OR Apache-2.0"
 description = "Oauth2 for Twitch endpoints"
 keywords = ["oauth", "twitch", "async", "asynchronous"]
-documentation = "https://docs.rs/twitch_oauth2/0.12.9"
+documentation = "https://docs.rs/twitch_oauth2/0.13.0"
 readme = "README.md"
 include = [
     "src/*",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Twitch OAuth2 | OAuth2 for Twitch endpoints
 
-[![github]](https://github.com/twitch-rs/twitch_oauth2)&ensp;[![crates-io]](https://crates.io/crates/twitch_oauth2)&ensp;[![docs-rs]](https://docs.rs/twitch_oauth2/0.12.9/twitch_oauth2)
+[![github]](https://github.com/twitch-rs/twitch_oauth2)&ensp;[![crates-io]](https://crates.io/crates/twitch_oauth2)&ensp;[![docs-rs]](https://docs.rs/twitch_oauth2/0.13.0/twitch_oauth2)
 
 [github]: https://img.shields.io/badge/github-twitch--rs/twitch__oauth2-8da0cb?style=for-the-badge&labelColor=555555&logo=github"
 [crates-io]: https://img.shields.io/crates/v/twitch_oauth2.svg?style=for-the-badge&color=fc8d62&logo=rust"

--- a/src/client.rs
+++ b/src/client.rs
@@ -91,6 +91,23 @@ pub enum SurfError {
     UrlError(#[from] url::ParseError),
 }
 
+// same as in twitch_api/src/client/surf_impl.rs
+#[cfg(feature = "surf")]
+fn http1_to_surf(m: &http::Method) -> surf::http::Method {
+    match *m {
+        http::Method::GET => surf::http::Method::Get,
+        http::Method::CONNECT => http_types::Method::Connect,
+        http::Method::DELETE => http_types::Method::Delete,
+        http::Method::HEAD => http_types::Method::Head,
+        http::Method::OPTIONS => http_types::Method::Options,
+        http::Method::PATCH => http_types::Method::Patch,
+        http::Method::POST => http_types::Method::Post,
+        http::Method::PUT => http_types::Method::Put,
+        http::Method::TRACE => http_types::Method::Trace,
+        _ => unimplemented!(),
+    }
+}
+
 #[cfg(feature = "surf")]
 impl Client for SurfClient {
     type Error = SurfError;
@@ -101,7 +118,7 @@ impl Client for SurfClient {
     ) -> BoxedFuture<'_, Result<http::Response<Vec<u8>>, Self::Error>> {
         // First we translate the `http::Request` method and uri into types that surf understands.
 
-        let method: surf::http::Method = request.method().clone().into();
+        let method = http1_to_surf(request.method());
 
         let url = match url::Url::parse(&request.uri().to_string()) {
             Ok(url) => url,
@@ -129,7 +146,10 @@ impl Client for SurfClient {
         Box::pin(async move {
             // Send the request and translate the response into a `http::Response`
             let mut response = client.send(req).await.map_err(SurfError::Surf)?;
-            let mut result = http::Response::builder().status(response.status());
+            let mut result = http::Response::builder().status(
+                http::StatusCode::from_u16(response.status().into())
+                    .expect("http_types::StatusCode only contains valid status codes"),
+            );
 
             let mut response_headers: http::header::HeaderMap = response
                 .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //!
 //! ## HTTP Requests
 //!
-//! To enable client features with a supported http library, enable the http library feature in `twitch_oauth2`, like `twitch_oauth2 = { features = ["reqwest"], version = "0.12.9" }`.
+//! To enable client features with a supported http library, enable the http library feature in `twitch_oauth2`, like `twitch_oauth2 = { features = ["reqwest"], version = "0.13.0" }`.
 //! If you're using [twitch_api](https://crates.io/crates/twitch_api), you can use its [`HelixClient`](https://docs.rs/twitch_api/latest/twitch_api/struct.HelixClient.html) instead of the underlying http client.
 //!
 //!


### PR DESCRIPTION
Supersedes #134.

I updated this and the main crate to http 1 and hyper (and other stuff that moved to http 1).

Only surf needed adaptation.

Towards https://github.com/twitch-rs/twitch_api/issues/401.