### PR TITLE
deps: update `displaydoc` to 0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,9 +633,9 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "displaydoc"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,3 +92,6 @@ features = ["all", "mock_api"]
 rustc-args = ["--cfg", "nightly"]
 rustdoc-args = ["--cfg", "nightly"]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(_internal_never)', 'cfg(nightly)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ all = ["surf_client_curl", "reqwest"]
 
 [dependencies]
 thiserror = "1.0.40"
-displaydoc = "0.2.4"
+displaydoc = "0.2.5"
 serde = { version = "1.0.163" }
 serde_derive = { version = "1.0.163" }
 serde_json = "1.0.96"


### PR DESCRIPTION
Updates `displaydoc` to 0.2.5 to fix a future incompatibility warning (see https://github.com/twitch-rs/twitch_api/issues/410).

Since we do merges, I've added a fix for the `unexpected_cfgs` lint in a separate commit.