### PR TITLE
Add new warning scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 [Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.13.0...Unreleased)
 
+### Changed
+
+- Added new scopes `moderator:read:warnings` and `moderator:manage:warnings`
+
 ## [v0.13.0] - 2024-04-04
 
 [Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.12.9...v0.13.0)

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -197,6 +197,7 @@ scope_impls!(
     ModeratorManageChatSettings,    scope: "moderator:manage:chat_settings",    doc: "View a broadcaster’s chat room settings.";
     ModeratorManageShieldMode,      scope: "moderator:manage:shield_mode",      doc: "Manage a broadcaster’s Shield Mode status.";
     ModeratorManageShoutouts,       scope: "moderator:manage:shoutouts",        doc: "Manage a broadcaster’s shoutouts.";
+    ModeratorManageWarnings,        scope: "moderator:manage:warnings",         doc: "Manage a broadcaster’s chat warnings.";
     ModeratorReadAutomodSettings,   scope: "moderator:read:automod_settings",   doc: "View a broadcaster’s AutoMod settings.";
     ModeratorReadBlockedTerms,      scope: "moderator:read:blocked_terms",      doc: "View a broadcaster’s list of blocked terms.";
     ModeratorReadChatSettings,      scope: "moderator:read:chat_settings",      doc: "View a broadcaster’s chat room settings.";
@@ -204,6 +205,7 @@ scope_impls!(
     ModeratorReadFollowers,         scope: "moderator:read:followers",          doc: "Read the followers of a broadcaster.";
     ModeratorReadShieldMode,        scope: "moderator:read:shield_mode",        doc: "View a broadcaster’s Shield Mode status.";
     ModeratorReadShoutouts,         scope: "moderator:read:shoutouts",          doc: "View a broadcaster’s shoutouts.";
+    ModeratorReadWarnings,          scope: "moderator:read:warnings",           doc: "View a broadcaster’s chat warnings.";
     UserBot,                        scope: "user:bot",                          doc: "Allows client’s bot to act as this user.";
     UserEdit,                       scope: "user:edit",                         doc: "Manage a user object.";
     UserEditBroadcast,              scope: "user:edit:broadcast",               doc: "Edit your channel's broadcast configuration, including extension configuration. (This scope implies user:read:broadcast capability.)";


### PR DESCRIPTION
These scopes aren't listed on Twitch's [scope list](https://dev.twitch.tv/docs/authentication/scopes/) yet, but are already referenced and required by

* [Helix `warn-chat-user`](https://dev.twitch.tv/docs/api/reference/#warn-chat-user)
* [EventSub `channel.moderate` v2](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelmoderate-v2)
* [EventSub `channel.warning.acknowledge`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelwarningacknowledge)
* [EventSub `channel.warning.send`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelwarningsend)