### PR TITLE
fix: update `struct_created` when refreshing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 [Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.14.0...Unreleased)
 
+### Fixed
+
+- `AppAccessToken` and `UserToken` now return the correct duration in `expires_in` after refreshing.
+
 ## [v0.14.0] - 2024-09-23
 
 [Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.13.0...v0.14.0)

--- a/src/tokens/app_access_token.rs
+++ b/src/tokens/app_access_token.rs
@@ -77,6 +77,7 @@ impl TwitchToken for AppAccessToken {
         self.access_token = access_token;
         self.expires_in = expires_in;
         self.refresh_token = refresh_token;
+        self.struct_created = std::time::Instant::now();
         Ok(())
     }
 

--- a/src/tokens/user_token.rs
+++ b/src/tokens/user_token.rs
@@ -311,6 +311,7 @@ impl TwitchToken for UserToken {
             self.access_token = access_token;
             self.expires_in = expires;
             self.refresh_token = refresh_token;
+            self.struct_created = std::time::Instant::now();
             Ok(())
         } else {
             return Err(RefreshTokenError::NoClientSecretFound);


### PR DESCRIPTION
Neither `UserToken` nor `AppAccessToken` updated their `struct_created` when refreshing, resulting in `expires_in` eventually returning 0 even after refreshing.

Fixes #150.