### PR TITLE
send refresh-token request in HTTP POST body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 [Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.15.2...Unreleased)
 
+### Changed
+
+- Send refresh-token request in HTTP POST body
+
 ## [v0.15.2] - 2025-03-05
 
 [Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.15.1...v0.15.2)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,8 +255,14 @@ impl RefreshTokenRef {
         client_id: &ClientId,
         client_secret: Option<&ClientSecret>,
     ) -> http::Request<Vec<u8>> {
-        use http::{HeaderMap, Method};
+        use http::{HeaderMap, HeaderValue, Method};
         use std::collections::HashMap;
+
+        let mut headers = HeaderMap::new();
+        headers.append(
+            "Content-Type",
+            HeaderValue::from_static("application/x-www-form-urlencoded"),
+        );
 
         let mut params = HashMap::new();
         params.insert("client_id", client_id.as_str());
@@ -265,13 +271,15 @@ impl RefreshTokenRef {
         }
         params.insert("grant_type", "refresh_token");
         params.insert("refresh_token", self.secret());
-
-        construct_request(
+        construct_request::<&[(String, String)], _, _>(
             &crate::TOKEN_URL,
-            &params,
-            HeaderMap::new(),
+            &[],
+            headers,
             Method::POST,
-            vec![],
+            url::form_urlencoded::Serializer::new(String::new())
+                .extend_pairs(params)
+                .finish()
+                .into_bytes(),
         )
     }
 


### PR DESCRIPTION
> https://github.com/twitch-rs/twitch_oauth2/pull/161#issuecomment-2718642784

[The doc](https://dev.twitch.tv/docs/authentication/refresh-tokens/#how-to-use-a-refresh-token) sends the request payload in HTTP body with verb POST.
