### PR TITLE
Use web-time when compiling for WebAssembly on web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,6 +2521,7 @@ dependencies = [
  "tokio",
  "twitch_types",
  "url",
+ "web-time",
 ]
 
 [[package]]
@@ -2716,6 +2717,16 @@ name = "web-sys"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ base64 = "0.22.0"
 rand = "0.8.5"
 twitch_types = { version = "0.4.3", features = ["serde"] }
 
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+web-time = { version = "1.1.0" }
+
 [dev-dependencies]
 tokio = { version = "1.40.0", features = [
     "rt-multi-thread",

--- a/src/tokens/app_access_token.rs
+++ b/src/tokens/app_access_token.rs
@@ -1,5 +1,11 @@
 use twitch_types::{UserIdRef, UserNameRef};
 
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+use std::time::Instant;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use web_time::Instant;
+
 #[cfg(feature = "client")]
 use super::errors::{AppAccessTokenError, ValidationError};
 #[cfg(feature = "client")]
@@ -27,7 +33,7 @@ pub struct AppAccessToken {
     /// Expiration from when the response was generated.
     expires_in: std::time::Duration,
     /// When this struct was created, not when token was created.
-    struct_created: std::time::Instant,
+    struct_created: Instant,
     client_id: ClientId,
     client_secret: ClientSecret,
     scopes: Vec<Scope>,
@@ -77,7 +83,7 @@ impl TwitchToken for AppAccessToken {
         self.access_token = access_token;
         self.expires_in = expires_in;
         self.refresh_token = refresh_token;
-        self.struct_created = std::time::Instant::now();
+        self.struct_created = Instant::now();
         Ok(())
     }
 
@@ -113,7 +119,7 @@ impl AppAccessToken {
             client_id: client_id.into(),
             client_secret: client_secret.into(),
             expires_in: expires_in.unwrap_or_default(),
-            struct_created: std::time::Instant::now(),
+            struct_created: Instant::now(),
             scopes: scopes.unwrap_or_default(),
         }
     }

--- a/src/tokens/user_token.rs
+++ b/src/tokens/user_token.rs
@@ -1,5 +1,11 @@
 use twitch_types::{UserId, UserIdRef, UserName, UserNameRef};
 
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+use std::time::Instant;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use web_time::Instant;
+
 use super::errors::ValidationError;
 #[cfg(feature = "client")]
 use super::errors::{
@@ -35,7 +41,7 @@ pub struct UserToken {
     /// Expiration from when the response was generated.
     expires_in: std::time::Duration,
     /// When this struct was created, not when token was created.
-    struct_created: std::time::Instant,
+    struct_created: Instant,
     scopes: Vec<Scope>,
     /// Token will never expire
     ///
@@ -240,7 +246,7 @@ impl UserToken {
             user_id,
             refresh_token: refresh_token.into(),
             expires_in: expires_in.unwrap_or(std::time::Duration::MAX),
-            struct_created: std::time::Instant::now(),
+            struct_created: Instant::now(),
             scopes: scopes.unwrap_or_default(),
             never_expiring: expires_in.is_none(),
         }
@@ -379,7 +385,7 @@ impl TwitchToken for UserToken {
         self.access_token = access_token;
         self.expires_in = expires;
         self.refresh_token = refresh_token;
-        self.struct_created = std::time::Instant::now();
+        self.struct_created = Instant::now();
         Ok(())
     }
 
@@ -921,7 +927,7 @@ pub struct DeviceUserTokenBuilder {
     client_id: ClientId,
     client_secret: Option<ClientSecret>,
     scopes: Vec<Scope>,
-    response: Option<(std::time::Instant, crate::id::DeviceCodeResponse)>,
+    response: Option<(Instant, crate::id::DeviceCodeResponse)>,
 }
 
 impl DeviceUserTokenBuilder {
@@ -966,7 +972,7 @@ impl DeviceUserTokenBuilder {
         response: http::Response<Vec<u8>>,
     ) -> Result<&crate::id::DeviceCodeResponse, crate::RequestParseError> {
         let response = crate::parse_response(&response)?;
-        self.response = Some((std::time::Instant::now(), response));
+        self.response = Some((Instant::now(), response));
         Ok(&self.response.as_ref().unwrap().1)
     }
 


### PR DESCRIPTION
This is primarily for programs that compile down to WebAssembly, such as websites using a Rust-based library or serverless platforms like Cloudflare Workers.

Without this, usage of the library would just crash when used in such platforms. ~~`web-time` is additive, so if it is enabled on native platforms, it just remaps down to std::time.~~