### PR TITLE
Return access and refresh tokens with `RetrieveTokenError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,6 +1303,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,9 +1374,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -2350,15 +2361,17 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes 1.5.0",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
+ "slab",
  "socket2 0.5.5",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -2366,9 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,9 @@ ignore = [
     # `instant` is unmaintained
     # Dependent on via surf (and http-types)
     "RUSTSEC-2024-0384",
+    # https://rustsec.org/advisories/RUSTSEC-2025-0036
+    # `surf` is unmaintained
+    "RUSTSEC-2025-0036",
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/examples/device_code_flow.rs
+++ b/examples/device_code_flow.rs
@@ -1,6 +1,6 @@
 //! Example of how to create a user token using device code flow.
 //! The device code flow can be used on confidential and public clients.
-use twitch_oauth2::{DeviceUserTokenBuilder, TwitchToken, UserToken};
+use twitch_oauth2::{DeviceUserTokenBuilder, TwitchToken};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -161,7 +161,7 @@ impl Client for SurfClient {
                 })
                 .collect::<Result<_, SurfError>>()?;
 
-            let _ = std::mem::replace(&mut result.headers_mut(), Some(&mut response_headers));
+            let _ = result.headers_mut().replace(&mut response_headers);
             let result = if let Some(v) = response.version() {
                 result.version(match v {
                     surf::http::Version::Http0_9 => http::Version::HTTP_09,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,9 +189,9 @@ impl AccessTokenRef {
     ///
     /// Should be checked on regularly, according to <https://dev.twitch.tv/docs/authentication/validate-tokens/>
     #[cfg(feature = "client")]
-    pub async fn validate_token<'a, C>(
+    pub async fn validate_token<C>(
         &self,
-        client: &'a C,
+        client: &C,
     ) -> Result<ValidatedToken, ValidationError<<C as Client>::Error>>
     where
         C: Client,
@@ -226,9 +226,9 @@ impl AccessTokenRef {
     ///
     /// See <https://dev.twitch.tv/docs/authentication/revoke-tokens/>
     #[cfg(feature = "client")]
-    pub async fn revoke_token<'a, C>(
+    pub async fn revoke_token<C>(
         &self,
-        http_client: &'a C,
+        http_client: &C,
         client_id: &ClientId,
     ) -> Result<(), RevokeTokenError<<C as Client>::Error>>
     where
@@ -287,9 +287,9 @@ impl RefreshTokenRef {
     ///
     /// See <https://dev.twitch.tv/docs/authentication/refresh-tokens>
     #[cfg(feature = "client")]
-    pub async fn refresh_token<'a, C>(
+    pub async fn refresh_token<C>(
         &self,
-        http_client: &'a C,
+        http_client: &C,
         client_id: &ClientId,
         client_secret: Option<&ClientSecret>,
     ) -> Result<

--- a/src/tokens/errors.rs
+++ b/src/tokens/errors.rs
@@ -41,7 +41,8 @@ impl ValidationError<std::convert::Infallible> {
 }
 
 /// Errors for [`UserToken::new`][crate::tokens::UserToken::new], [`UserToken::from_token`][crate::tokens::UserToken::from_token], [`UserToken::from_existing`][crate::tokens::UserToken::from_existing] and [`UserToken::from_response`][crate::tokens::UserToken::from_response]
-#[derive(thiserror::Error, Debug, displaydoc::Display)]
+#[derive(thiserror::Error, Debug)]
+#[error("creation of token failed")]
 pub struct CreationError<RE: std::error::Error + Send + Sync + 'static> {
     /// Access token passed to the function
     pub access_token: AccessToken,
@@ -70,7 +71,7 @@ impl<RE: std::error::Error + Send + Sync + 'static>
     }
 }
 
-/// Error kinds for [UserToken::from_refresh_token][crate::UserToken::from_refresh_token] and [UserToken::UserToken::from_existing_or_refresh_token][crate::UserToken::from_existing_or_refresh_token]
+/// Errors for [UserToken::from_refresh_token][crate::UserToken::from_refresh_token] and [UserToken::UserToken::from_existing_or_refresh_token][crate::UserToken::from_existing_or_refresh_token]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 #[non_exhaustive]
 #[cfg(feature = "client")]

--- a/src/tokens/errors.rs
+++ b/src/tokens/errors.rs
@@ -1,6 +1,5 @@
 //! Errors
 
-#[cfg(feature = "client")]
 use crate::{AccessToken, RefreshToken};
 
 /// General errors for talking with twitch, used in [`AppAccessToken::get_app_access_token`](crate::tokens::AppAccessToken::get_app_access_token)
@@ -15,7 +14,7 @@ pub enum AppAccessTokenError<RE: std::error::Error + Send + Sync + 'static> {
     RequestParseError(#[from] crate::RequestParseError),
 }
 
-/// Errors for [AccessToken::validate_token][crate::AccessTokenRef::validate_token] and [UserToken::from_response][crate::tokens::UserToken::from_response]
+/// Errors for [AccessToken::validate_token][crate::AccessTokenRef::validate_token]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 #[non_exhaustive]
 pub enum ValidationError<RE: std::error::Error + Send + Sync + 'static> {
@@ -37,6 +36,36 @@ impl ValidationError<std::convert::Infallible> {
             ValidationError::RequestParseError(e) => ValidationError::RequestParseError(e),
             ValidationError::InvalidToken(s) => ValidationError::InvalidToken(s),
             ValidationError::Request(_) => unreachable!(),
+        }
+    }
+}
+
+/// Errors for [`UserToken::new`][crate::tokens::UserToken::new], [`UserToken::from_token`][crate::tokens::UserToken::from_token], [`UserToken::from_existing`][crate::tokens::UserToken::from_existing] and [`UserToken::from_response`][crate::tokens::UserToken::from_response]
+#[derive(thiserror::Error, Debug, displaydoc::Display)]
+pub struct CreationError<RE: std::error::Error + Send + Sync + 'static> {
+    /// Access token passed to the function
+    pub access_token: AccessToken,
+    /// Refresh token passed to the function
+    pub refresh_token: Option<RefreshToken>,
+    /// Error validating the token
+    #[source]
+    pub error: ValidationError<RE>,
+}
+
+impl<RE: std::error::Error + Send + Sync + 'static>
+    From<(AccessToken, Option<RefreshToken>, ValidationError<RE>)> for CreationError<RE>
+{
+    fn from(
+        (access_token, refresh_token, error): (
+            AccessToken,
+            Option<RefreshToken>,
+            ValidationError<RE>,
+        ),
+    ) -> Self {
+        Self {
+            access_token,
+            refresh_token,
+            error,
         }
     }
 }
@@ -64,6 +93,37 @@ pub enum RetrieveTokenError<RE: std::error::Error + Send + Sync + 'static> {
         /// Refresh token passed to the function
         refresh_token: RefreshToken,
     },
+}
+
+#[cfg(feature = "client")]
+impl<RE: std::error::Error + Send + Sync + 'static> From<CreationError<RE>>
+    for RetrieveTokenError<RE>
+{
+    fn from(
+        CreationError {
+            error,
+            access_token,
+            refresh_token,
+        }: CreationError<RE>,
+    ) -> Self {
+        RetrieveTokenError::ValidationError {
+            error,
+            access_token,
+            refresh_token,
+        }
+    }
+}
+
+#[cfg(feature = "client")]
+impl CreationError<std::convert::Infallible> {
+    /// Convert this error from a infallible to another
+    pub fn into_other<RE: std::error::Error + Send + Sync + 'static>(self) -> CreationError<RE> {
+        CreationError {
+            access_token: self.access_token,
+            refresh_token: self.refresh_token,
+            error: self.error.into_other(),
+        }
+    }
 }
 
 /// Errors for [AccessToken::revoke_token][crate::AccessTokenRef::revoke_token]
@@ -113,6 +173,15 @@ pub enum UserTokenExchangeError<RE: std::error::Error + Send + Sync + 'static> {
     ValidationError(#[from] ValidationError<RE>),
 }
 
+#[cfg(feature = "client")]
+impl<RE: std::error::Error + Send + Sync + 'static> From<CreationError<RE>>
+    for UserTokenExchangeError<RE>
+{
+    fn from(value: CreationError<RE>) -> Self {
+        UserTokenExchangeError::ValidationError(value.error)
+    }
+}
+
 /// Errors for [ImplicitUserTokenBuilder::get_user_token][crate::tokens::ImplicitUserTokenBuilder::get_user_token]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 #[non_exhaustive]
@@ -131,6 +200,16 @@ pub enum ImplicitUserTokenExchangeError<RE: std::error::Error + Send + Sync + 's
     /// could not get validation for token
     ValidationError(#[from] ValidationError<RE>),
 }
+
+#[cfg(feature = "client")]
+impl<RE: std::error::Error + Send + Sync + 'static> From<CreationError<RE>>
+    for ImplicitUserTokenExchangeError<RE>
+{
+    fn from(value: CreationError<RE>) -> Self {
+        ImplicitUserTokenExchangeError::ValidationError(value.error)
+    }
+}
+
 /// Errors for [`DeviceUserTokenBuilder`][crate::tokens::DeviceUserTokenBuilder]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 #[non_exhaustive]
@@ -162,5 +241,14 @@ impl<RE: std::error::Error + Send + Sync + 'static> DeviceUserTokenExchangeError
                     ..
                 }),
             ) if message == "authorization_pending")
+    }
+}
+
+#[cfg(feature = "client")]
+impl<RE: std::error::Error + Send + Sync + 'static> From<CreationError<RE>>
+    for DeviceUserTokenExchangeError<RE>
+{
+    fn from(value: CreationError<RE>) -> Self {
+        DeviceUserTokenExchangeError::ValidationError(value.error)
     }
 }

--- a/src/tokens/errors.rs
+++ b/src/tokens/errors.rs
@@ -41,50 +41,29 @@ impl ValidationError<std::convert::Infallible> {
     }
 }
 
-/// Errors for [UserToken::from_refresh_token][crate::UserToken::from_refresh_token] and [UserToken::UserToken::from_existing_or_refresh_token][crate::UserToken::from_existing_or_refresh_token] with used tokens
-#[derive(thiserror::Error, Debug, displaydoc::Display)]
-#[cfg(feature = "client")]
-pub struct RetrieveTokenError<RE: std::error::Error + Send + Sync + 'static> {
-    access_token: Option<AccessToken>,
-    refresh_token: Option<RefreshToken>,
-    kind: RetrieveTokenErrorKind<RE>,
-}
-
-#[cfg(feature = "client")]
-impl<RE: std::error::Error + Send + Sync + 'static> RetrieveTokenError<RE> {
-    pub(crate) fn from_refresh(
-        kind: RetrieveTokenErrorKind<RE>,
-        refresh_token: Option<RefreshToken>,
-    ) -> Self {
-        Self {
-            access_token: None,
-            refresh_token,
-            kind,
-        }
-    }
-
-    pub(crate) fn from_kind(
-        kind: RetrieveTokenErrorKind<RE>,
-        access_token: AccessToken,
-        refresh_token: Option<RefreshToken>,
-    ) -> Self {
-        Self {
-            access_token: Some(access_token),
-            refresh_token,
-            kind,
-        }
-    }
-}
-
 /// Error kinds for [UserToken::from_refresh_token][crate::UserToken::from_refresh_token] and [UserToken::UserToken::from_existing_or_refresh_token][crate::UserToken::from_existing_or_refresh_token]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 #[non_exhaustive]
 #[cfg(feature = "client")]
-pub enum RetrieveTokenErrorKind<RE: std::error::Error + Send + Sync + 'static> {
+pub enum RetrieveTokenError<RE: std::error::Error + Send + Sync + 'static> {
     /// could not validate token
-    ValidationError(#[from] ValidationError<RE>),
+    ValidationError {
+        /// Error validating the token
+        #[source]
+        error: ValidationError<RE>,
+        /// Access token passed to the function
+        access_token: AccessToken,
+        /// Refresh token passed to the function
+        refresh_token: Option<RefreshToken>,
+    },
     /// could not refresh token
-    RefreshTokenError(#[from] RefreshTokenError<RE>),
+    RefreshTokenError {
+        /// Error refreshing the token
+        #[source]
+        error: RefreshTokenError<RE>,
+        /// Refresh token passed to the function
+        refresh_token: RefreshToken,
+    },
 }
 
 /// Errors for [AccessToken::revoke_token][crate::AccessTokenRef::revoke_token]

--- a/src/tokens/errors.rs
+++ b/src/tokens/errors.rs
@@ -1,5 +1,8 @@
 //! Errors
 
+#[cfg(feature = "client")]
+use crate::{AccessToken, RefreshToken};
+
 /// General errors for talking with twitch, used in [`AppAccessToken::get_app_access_token`](crate::tokens::AppAccessToken::get_app_access_token)
 #[allow(missing_docs)]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
@@ -38,11 +41,46 @@ impl ValidationError<std::convert::Infallible> {
     }
 }
 
-/// Errors for [UserToken::from_refresh_token][crate::UserToken::from_refresh_token] and [UserToken::UserToken::from_existing_or_refresh_token][crate::UserToken::from_existing_or_refresh_token]
+/// Errors for [UserToken::from_refresh_token][crate::UserToken::from_refresh_token] and [UserToken::UserToken::from_existing_or_refresh_token][crate::UserToken::from_existing_or_refresh_token] with used tokens
+#[derive(thiserror::Error, Debug, displaydoc::Display)]
+#[cfg(feature = "client")]
+pub struct RetrieveTokenError<RE: std::error::Error + Send + Sync + 'static> {
+    access_token: Option<AccessToken>,
+    refresh_token: Option<RefreshToken>,
+    kind: RetrieveTokenErrorKind<RE>,
+}
+
+#[cfg(feature = "client")]
+impl<RE: std::error::Error + Send + Sync + 'static> RetrieveTokenError<RE> {
+    pub(crate) fn from_refresh(
+        kind: RetrieveTokenErrorKind<RE>,
+        refresh_token: Option<RefreshToken>,
+    ) -> Self {
+        Self {
+            access_token: None,
+            refresh_token,
+            kind,
+        }
+    }
+
+    pub(crate) fn from_kind(
+        kind: RetrieveTokenErrorKind<RE>,
+        access_token: AccessToken,
+        refresh_token: Option<RefreshToken>,
+    ) -> Self {
+        Self {
+            access_token: Some(access_token),
+            refresh_token,
+            kind,
+        }
+    }
+}
+
+/// Error kinds for [UserToken::from_refresh_token][crate::UserToken::from_refresh_token] and [UserToken::UserToken::from_existing_or_refresh_token][crate::UserToken::from_existing_or_refresh_token]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 #[non_exhaustive]
 #[cfg(feature = "client")]
-pub enum RetrieveTokenError<RE: std::error::Error + Send + Sync + 'static> {
+pub enum RetrieveTokenErrorKind<RE: std::error::Error + Send + Sync + 'static> {
     /// could not validate token
     ValidationError(#[from] ValidationError<RE>),
     /// could not refresh token


### PR DESCRIPTION
Pull request for #167 

Changes signatures of several functions to include access and refresh tokens to include them in `RetrieveTokenError` and moves variants to `RetrieveTokenErrorKind`. 

