### PR TITLE
fix: remove removed `doc_auto_cfg` feature and intra-doc links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![deny(missing_docs, broken_intra_doc_links)] // This will be weird until 1.52, see https://github.com/rust-lang/rust/pull/80527
 #![cfg_attr(nightly, deny(rustdoc::broken_intra_doc_links))]
 #![cfg_attr(nightly, feature(doc_cfg))]
-#![cfg_attr(nightly, feature(doc_auto_cfg))]
 //! [![github]](https://github.com/twitch-rs/twitch_oauth2)&ensp;[![crates-io]](https://crates.io/crates/twitch_oauth2)&ensp;[![docs-rs]](https://docs.rs/twitch_oauth2/0.8.0/twitch_oauth2)
 //!
 //! [github]: https://img.shields.io/badge/github-twitch--rs/twitch__oauth2-8da0cb?style=for-the-badge&labelColor=555555&logo=github"

--- a/src/scopes/validator.rs
+++ b/src/scopes/validator.rs
@@ -238,7 +238,7 @@ impl Validator {
     ///
     /// # Notes
     ///
-    /// This function doesn't do anything, but it powers the [validator!] macro
+    /// This function doesn't do anything, but it powers the [validator!][crate::validator] macro
     #[doc(hidden)]
     pub const fn to_validator(self) -> Self { self }
 }
@@ -390,7 +390,7 @@ macro_rules! validator {
     }};
 }
 
-/// Logical operators for the [validator!] macro.
+/// Logical operators for the [validator!][crate::validator] macro.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! validator_logic {
@@ -414,7 +414,7 @@ macro_rules! validator_logic {
     }
 }
 
-/// Accumulator for the [validator!] macro.
+/// Accumulator for the [validator!][crate::validator] macro.
 // Thanks to danielhenrymantilla, the macro wizard
 #[doc(hidden)]
 #[macro_export]


### PR DESCRIPTION
`doc_auto_cfg` was removed in https://redirect.github.com/rust-lang/rust/pull/138907. Tested locally that features are still shown (see `cfg` above removed line). Found that some intra-doc were broken and fixed them.