### PR TITLE
release twitch_oauth2 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ## [Unreleased] - ReleaseDate
 
-[Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.15.2...Unreleased)
+[Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.16.0...Unreleased)
+
+## [v0.16.0] - 2025-10-05
+
+[Commits](https://github.com/twitch-rs/twitch_oauth2/compare/v0.15.2...v0.16.0)
 
 ### Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,7 +1440,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twitch_oauth2"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "aliri_braid",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "twitch_oauth2"
-version = "0.15.2"
+version = "0.16.0"
 edition = "2021"
 repository = "https://github.com/twitch-rs/twitch_oauth2"
 license = "MIT OR Apache-2.0"
 description = "Oauth2 for Twitch endpoints"
 keywords = ["oauth", "twitch", "async", "asynchronous"]
-documentation = "https://docs.rs/twitch_oauth2/0.15.2"
+documentation = "https://docs.rs/twitch_oauth2/0.16.0"
 readme = "README.md"
 include = [
     "src/*",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Twitch OAuth2 | OAuth2 for Twitch endpoints
 
-[![github]](https://github.com/twitch-rs/twitch_oauth2)&ensp;[![crates-io]](https://crates.io/crates/twitch_oauth2)&ensp;[![docs-rs]](https://docs.rs/twitch_oauth2/0.15.2/twitch_oauth2)
+[![github]](https://github.com/twitch-rs/twitch_oauth2)&ensp;[![crates-io]](https://crates.io/crates/twitch_oauth2)&ensp;[![docs-rs]](https://docs.rs/twitch_oauth2/0.16.0/twitch_oauth2)
 
 [github]: https://img.shields.io/badge/github-twitch--rs/twitch__oauth2-8da0cb?style=for-the-badge&labelColor=555555&logo=github"
 [crates-io]: https://img.shields.io/crates/v/twitch_oauth2.svg?style=for-the-badge&color=fc8d62&logo=rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //!
 //! ## HTTP Requests
 //!
-//! To enable client features with a supported http library, enable the http library feature in `twitch_oauth2`, like `twitch_oauth2 = { features = ["reqwest"], version = "0.15.2" }`.
+//! To enable client features with a supported http library, enable the http library feature in `twitch_oauth2`, like `twitch_oauth2 = { features = ["reqwest"], version = "0.16.0" }`.
 //! If you're using [twitch_api](https://crates.io/crates/twitch_api), you can use its [`HelixClient`](https://docs.rs/twitch_api/latest/twitch_api/struct.HelixClient.html) instead of the underlying http client.
 //!
 //!


### PR DESCRIPTION
Minor release because of the breaking change.

---
## Changelog

### Breaking

- Removed surf dependency and related feature flags
### Added
- Added `Hash` derive to `Scopes`.
### Changed
- Send refresh-token request in HTTP POST body