### PR TITLE
deps: update `anyhow` to 1.0.103

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "atomic-waker"


### PR DESCRIPTION
Due to [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190.html): Unsoundness in `Error::downcast_mut()`.